### PR TITLE
Default to 1:1 aspect ratio on MDS plot

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -18,6 +18,7 @@
 plot.qualpal <- function(x, ...) {
   args <- list(
     x = stats::cmdscale(x$de_DIN99d, k = if (length(x$hex) == 2) 1 else 2),
+    asp = 1,
     col = x$hex,
     cex = 3,
     pch = 19,


### PR DESCRIPTION
Thanks for this great package!

I notice that the MDS plot shown in the vignette is wider than high, which will misrepresent the true distances between colorus.  Using the `asp` parameter to impose a 1:1 aspect ratio will mean that the plot is representative.  It seems appropriate to include this as the default behaviour of the plotting function.