### PR TITLE
feat: add `extend` argument to `qualpal()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   release. There is no direct replacement.
 - There's a new function, `analyze_palette()`, which analyzes a categorical
   color palette.
+- `qualpal()` now has a `extend` method that allows the user to extend
+  an existing palette by adding more colors to it. This is useful for
+  expanding an existing palette to include more colors.
 
 ## Refactoring
 

--- a/R/qualpal.R
+++ b/R/qualpal.R
@@ -68,6 +68,11 @@
 #'   via \code{\link[grDevices]{col2rgb}} is acceptable, including hex colors.
 #' @param metric The color metric to use for the color distance
 #'   matrix.
+#' @param extend A palette of colors to use as a fixed set of initial
+#'   colors in the palette, which can be either a matrix or data frame
+#'   of RGB values (with values between 0 and 1) or a character vector
+#'   of hex colors (or any other format that's acceptable in
+#'   [grDevices::col2rgb()]).
 #'
 #' @return A list of class \code{qualpal} with the following
 #'   components.
@@ -114,7 +119,8 @@ qualpal <- function(
   cvd = c("protan", "deutan", "tritan"),
   cvd_severity = 0,
   bg = NULL,
-  metric = c("din99d", "ciede2000", "cie76")
+  metric = c("din99d", "ciede2000", "cie76"),
+  extend = NULL
 ) {
   UseMethod("qualpal", colorspace)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,10 +8,20 @@ make_options <- function(
   cvd = c("protan", "deutan", "tritan"),
   cvd_severity = 0,
   bg = NULL,
-  metric = c("din99d", "ciede2000", "cie76")
+  metric = c("din99d", "ciede2000", "cie76"),
+  extend = NULL
 ) {
   cvd <- match.arg(cvd)
   metric <- match.arg(metric)
+
+  if (is.null(extend)) {
+    extend <- matrix(0, nrow = 0, ncol = 3)
+  } else if (is.character(extend)) {
+    extend <- grDevices::col2rgb(extend)
+    extend <- t(extend) / 255
+  } else if (is.data.frame(extend)) {
+    extend <- as.matrix(extend)
+  }
 
   stopifnot(
     is.character(cvd),
@@ -20,7 +30,9 @@ make_options <- function(
     length(cvd_severity) == 1,
     cvd_severity >= 0,
     cvd_severity <= 1,
-    is.null(bg) || (is.character(bg) && length(bg) == 1)
+    is.null(bg) || (is.character(bg) && length(bg) == 1),
+    is.matrix(extend),
+    ncol(extend) == 3
   )
 
   cvd_list <- list()
@@ -32,5 +44,5 @@ make_options <- function(
   } else {
     bg <- double(0)
   }
-  list(cvd = cvd_list, bg = bg, metric = metric)
+  list(cvd = cvd_list, bg = bg, metric = metric, extend = extend)
 }

--- a/man/qualpal.Rd
+++ b/man/qualpal.Rd
@@ -10,7 +10,8 @@ qualpal(
   cvd = c("protan", "deutan", "tritan"),
   cvd_severity = 0,
   bg = NULL,
-  metric = c("din99d", "ciede2000", "cie76")
+  metric = c("din99d", "ciede2000", "cie76"),
+  extend = NULL
 )
 }
 \arguments{
@@ -53,6 +54,12 @@ via \code{\link[grDevices]{col2rgb}} is acceptable, including hex colors.}
 
 \item{metric}{The color metric to use for the color distance
 matrix.}
+
+\item{extend}{A palette of colors to use as a fixed set of initial
+colors in the palette, which can be either a matrix or data frame
+of RGB values (with values between 0 and 1) or a character vector
+of hex colors (or any other format that's acceptable in
+\code{\link[grDevices:col2rgb]{grDevices::col2rgb()}}).}
 }
 \value{
 A list of class \code{qualpal} with the following

--- a/src/qualpalr.cpp
+++ b/src/qualpalr.cpp
@@ -87,7 +87,6 @@ organize_output(const std::vector<qualpal::colors::RGB> colors)
 
   std::vector<std::string> hex_out;
 
-  // for (const auto& rgb : selected_colors) {
   for (int i = 0; i < n; ++i) {
     RGB rgb = colors[i];
     DIN99d din99d(rgb);
@@ -163,7 +162,21 @@ qualpal_cpp_rgb(int n,
   }
 
   auto qp = setup_palette(options);
-  auto selected_colors = qp.setInputRGB(rgb_colors).generate(n);
+  qp.setInputRGB(rgb_colors);
+
+  auto extend = Rcpp::as<Rcpp::NumericMatrix>(options["extend"]);
+
+  std::vector<qualpal::colors::RGB> selected_colors;
+
+  if (extend.nrow() > 0) {
+    std::vector<qualpal::colors::RGB> base_colors;
+    for (int i = 0; i < extend.nrow(); ++i) {
+      base_colors.emplace_back(extend(i, 0), extend(i, 1), extend(i, 2));
+    }
+    selected_colors = qp.extend(base_colors, n);
+  } else {
+    selected_colors = qp.generate(n);
+  }
 
   return organize_output(selected_colors);
 }
@@ -176,6 +189,7 @@ qualpal_cpp_colorspace(int n,
                        const Rcpp::List& options)
 {
   auto qp = setup_palette(options);
+  auto extend = Rcpp::as<Rcpp::NumericMatrix>(options["extend"]);
 
   std::vector<double> h_lim_vec =
     Rcpp::as<std::vector<double>>(hsl_colorspace["h"]);
@@ -188,10 +202,20 @@ qualpal_cpp_colorspace(int n,
   std::array<double, 2> s_lim = { s_lim_vec[0], s_lim_vec[1] };
   std::array<double, 2> l_lim = { l_lim_vec[0], l_lim_vec[1] };
 
-  auto selected_colors = qualpal::Qualpal{}
-                           .setInputColorspace(h_lim, s_lim, l_lim)
-                           .setColorspaceSize(n_points)
-                           .generate(n);
+  qp.setInputColorspace(h_lim, s_lim, l_lim);
+  qp.setColorspaceSize(n_points);
+
+  std::vector<qualpal::colors::RGB> selected_colors;
+
+  if (extend.nrow() > 0) {
+    std::vector<qualpal::colors::RGB> base_colors;
+    for (int i = 0; i < extend.nrow(); ++i) {
+      base_colors.emplace_back(extend(i, 0), extend(i, 1), extend(i, 2));
+    }
+    selected_colors = qp.extend(base_colors, n);
+  } else {
+    selected_colors = qp.generate(n);
+  }
 
   return organize_output(selected_colors);
 }
@@ -202,8 +226,21 @@ qualpal_cpp_palette(int n,
                     const std::string& palette,
                     const Rcpp::List& options)
 {
+  auto extend = Rcpp::as<Rcpp::NumericMatrix>(options["extend"]);
   auto qp = setup_palette(options);
-  auto selected_colors = qp.setInputPalette(palette).generate(n);
+  qp.setInputPalette(palette);
+
+  std::vector<qualpal::colors::RGB> selected_colors;
+
+  if (extend.nrow() > 0) {
+    std::vector<qualpal::colors::RGB> base_colors;
+    for (int i = 0; i < extend.nrow(); ++i) {
+      base_colors.emplace_back(extend(i, 0), extend(i, 1), extend(i, 2));
+    }
+    selected_colors = qp.extend(base_colors, n);
+  } else {
+    selected_colors = qp.generate(n);
+  }
 
   return organize_output(selected_colors);
 }

--- a/tests/testthat/test_qualpal.R
+++ b/tests/testthat/test_qualpal.R
@@ -46,3 +46,17 @@ test_that("proper use of qualpal() works", {
   expect_silent(qualpal(9, bg = "#00ff00"))
   expect_silent(qualpal(9, metric = "ciede2000"))
 })
+
+test_that("extending a palette", {
+  base_pal <- qualpal(3)
+
+  base_pal_hex <- base_pal$hex
+  base_pal_rgb <- t(col2rgb(base_pal_hex)) / 255
+
+  expect_no_failure(qualpal(3, extend = base_pal_hex))
+  expect_no_failure(qualpal(5, extend = base_pal_hex))
+  expect_no_failure(qualpal(9, extend = base_pal_rgb))
+
+  expect_error(qualpal(5, extend = "notacolor"))
+  expect_error(qualpal(2, extend = base_pal_hex))
+})


### PR DESCRIPTION
Add a new argument that allows users to extend existing palettes by adding additional colors from any of the current inputs.

Closes #5